### PR TITLE
[feat] useRequest 훅 및 구현

### DIFF
--- a/src/hooks/useRequest.tsx
+++ b/src/hooks/useRequest.tsx
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from 'react';
+import fetch, { axiosOptions } from '@/services/utils/fetch';
+
+interface Props {
+  deps?: (boolean | string | number)[];
+  skip?: boolean;
+  options: axiosOptions;
+}
+
+function useRequest<T>({ deps = [], skip = false, options }: Props) {
+  const [data, setData] = useState<T>();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+
+  const refetch = useCallback(
+    async (args?: axiosOptions) => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const { data: fetchedData } = await fetch({ ...options, ...args });
+        setData(() => fetchedData);
+        return { data: fetchedData };
+      } catch (err) {
+        setError(() => err);
+        return { error: err };
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [options],
+  );
+
+  useEffect(() => {
+    if (skip) return;
+    refetch();
+  }, deps);
+
+  return { data, isLoading, error, fetch: refetch };
+}
+
+export default useRequest;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,14 +1,6 @@
-import useRequest from '@/hooks/useRequest';
 import SideMenu from '@/components/SideMenu';
 
 function Home() {
-  const { data, error } = useRequest({
-    options: {
-      url: '/users/me',
-      method: 'get',
-    },
-  });
-
   return (
     <div>
       <SideMenu />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,14 @@
-import Header from '@/components/Header';
+import useRequest from '@/hooks/useRequest';
 import SideMenu from '@/components/SideMenu';
 
 function Home() {
+  const { data, error } = useRequest({
+    options: {
+      url: '/users/me',
+      method: 'get',
+    },
+  });
+
   return (
     <div>
       <SideMenu />

--- a/src/services/config/default.ts
+++ b/src/services/config/default.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import { getAccessToken } from '../utils/handleToken';
+
+export const defaultInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+  timeout: 10000,
+});
+
+defaultInstance.interceptors.request.use((config) => {
+  const accessToken = getAccessToken();
+
+  if (accessToken) {
+    config.headers.Authorization = `Bearer ${accessToken}`;
+  }
+
+  return config;
+});

--- a/src/services/utils/fetch.ts
+++ b/src/services/utils/fetch.ts
@@ -1,0 +1,23 @@
+import { defaultInstance } from '../config/default';
+
+export interface axiosOptions {
+  url?: string;
+  method?: string;
+  params?: {
+    [param: string]: string | number | boolean;
+  };
+  data?: {
+    [data: string]: string | number | boolean;
+  };
+  headers?: {
+    Authorization?: string;
+  };
+}
+
+const fetch = async (options: axiosOptions) => {
+  const client = defaultInstance({ ...options });
+  await client;
+  return client;
+};
+
+export default fetch;

--- a/src/services/utils/handleToken.ts
+++ b/src/services/utils/handleToken.ts
@@ -1,0 +1,19 @@
+const ACCESS_TOKEN = 'accessToken';
+
+export const setAccessToken = (value: string) => {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(ACCESS_TOKEN, value);
+  }
+};
+
+export const getAccessToken = () => {
+  if (typeof window !== 'undefined') {
+    return localStorage.getItem(ACCESS_TOKEN);
+  }
+};
+
+export const removeAccessToken = () => {
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem(ACCESS_TOKEN);
+  }
+};


### PR DESCRIPTION
## 변경 사항
Close #40 
useRequest 훅을 구현했습니다.

## 사용 방법
useRequest 훅은 파라미터로 { deps, skip, options } 파라미터를 받습니다.
- deps는 특정 값의 변화에 따라 데이터를 다시 받아오고 싶을 때 사용합니다. 훅 내부에서 해당 값을 useEffect의 dependency로 보내주고 있습니다.
- skip은 훅을 불러오자마자 데이터를 가져오지 싶지 않을 때 사용합니다. 해당 옵션을 true로 해둘 경우 훅을 불었을 때가 아닌 fetch 함수를 따로 호출 했을 때 데이터를 불러옵니다.
- options는 axios instance의 파라미터를 객체로 받습니다.

리턴 값으로는 { data, error, isLoading, fetch } 객체를 줍니다.
- fetch 함수는 해당 url로 요청을 다시 보내고 싶을 때 사용합니다.

useRequest 훅을 통해 보낸 요청은 로컬 스토리지에 accessToken이 존재할 때 interceptor을 활용하여 headers.Authorization에 해당 토큰을 포함시켜 보내줍니다. 따라서 따로 훅 내부에 토큰을 넣어주지 않아도 됩니다.

다음은 회원가입 요청에 대한 예시입니다.
```ts
const { data, fetch: signup } = useRequest({
  skip: true,
  options: {
    url: '/users',
    method: 'get',
    data: {
      email: 'test@test.com',
      password: 'abcd1234',
      nickname: '홍길동',
    },
  },
});

const handleSignup = () => {
  signup();
};
```
