### PR TITLE
[refactor] 사이즈표 수정

### DIFF
--- a/src/components/buttons/DashboardButton.tsx
+++ b/src/components/buttons/DashboardButton.tsx
@@ -2,7 +2,7 @@ import { ButtonHTMLAttributes, ReactNode } from 'react';
 
 const DASHBOARD_BUTTON_SIZE = {
   sm: 'body1-normal w-full h-32 tablet:h-40',
-  lg: 'subheading-bold w-full h-60 tablet:h-70 pc:w-340',
+  lg: 'subheading-bold w-full h-60 tablet:h-70',
 };
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {

--- a/src/components/buttons/index.ts
+++ b/src/components/buttons/index.ts
@@ -5,7 +5,7 @@ import PrimaryButton from './PrimaryButton';
 import SecondaryButton from './SecondaryButton';
 
 export const BUTTON_SIZE = {
-  sm: 'body1-normal px-16 w-fit h-30 tablet:36 pc:h-40',
+  sm: 'body1-normal px-16 w-fit h-30 tablet:36',
   md: 'body2-normal w-109 h-28 tablet:w-72 tablet:h-30 pc:w-84 pc:h-32',
   lg: 'body1-normal w-138 h-42 tablet:w-120 tablet:h-48',
   full: 'subheading-normal w-full h-40',


### PR DESCRIPTION
## 변경 사항
Close #53 
버튼의 사이즈표를 수정했습니다.

### Primary, Secondary, Outline 
> sm: 'body1-normal px-16 w-fit h-30 tablet:36 pc: 40'

sm: 'body1-normal px-16 w-fit h-30 tablet:36'

### Dashboard
> lg: 'subheading-bold w-full h-60 tablet:h-70 pc: 340'

lg: 'subheading-bold w-full h-60 tablet:h-70'