### PR TITLE
[feat] 대시보드 페이지 헤더 구현

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,25 +1,97 @@
+import { useAtomValue } from 'jotai';
+import { useRouter } from 'next/router';
+import { loginAtom } from '@/store/loginAtom';
+import { Mock_members } from '@/pages/api/mock';
+import { Button } from '@/components/buttons';
+import { IconAddBox, IconSettings } from '@/public/svgs';
+import Members from './Members';
 import Logo from './logos/Logo';
 
 function Header() {
+  const loginInfo = useAtomValue(loginAtom);
+
+  return <>{loginInfo.isLoggedIn ? <MyHeader /> : <DefaultHeader />}</>;
+}
+
+export default Header;
+
+function DefaultHeader() {
   return (
     <div className='flex h-60 w-full max-w-[120rem] items-center justify-between bg-white px-24 tablet:h-70 tablet:pl-16 tablet:pr-40 pc:pr-80'>
       <div className='pl-4 pt-4'>
         <Logo />
       </div>
       <div className='flex gap-20 tablet:gap-36'>
-        <Button>로그인</Button>
-        <Button>회원가입</Button>
+        <TransparentButton>로그인</TransparentButton>
+        <TransparentButton>회원가입</TransparentButton>
       </div>
     </div>
   );
 }
 
-export default Header;
-
-function Button({ children }: { children: string }) {
+function TransparentButton({ children }: { children: string }) {
   return (
     <button className='button body1-normal hover:body1-bold text-gray-7'>
       {children}
     </button>
+  );
+}
+
+function MyHeader() {
+  const router = useRouter();
+  const title = '내 대시보드';
+
+  return (
+    <div className='flex h-60 items-center justify-between border-b border-solid border-gray-3 pl-24 pr-12 tablet:h-70 tablet:px-40 pc:pr-80'>
+      <div className='heading2-bold pl-4 pt-4'>{title}</div>
+      <div className='flex-center body1-normal gap-12 tablet:gap-24'>
+        {router.pathname === '/mydashboard' && <DashBoardInfo />}
+        <ProfileInfo />
+      </div>
+    </div>
+  );
+}
+
+function ProfileInfo() {
+  const loginInfo = useAtomValue(loginAtom);
+  const myProfile = {
+    id: loginInfo.id ?? 1,
+    nickname: loginInfo.nickname ?? '홍길동',
+    profileImageUrl: loginInfo.profileImageUrl,
+  };
+
+  return (
+    <div className='flex-center gap-12'>
+      <Members members={[myProfile]} />
+      <div className='hidden tablet:block'>{myProfile.nickname}</div>
+    </div>
+  );
+}
+
+function DashBoardInfo() {
+  return (
+    <div className='flex-center h-34 gap-16 border-r border-gray-3 pr-12 text-gray-5 tablet:h-38 tablet:gap-23 tablet:pr-24 pc:gap-40'>
+      <DashboardManageButton />
+      <Members members={Mock_members.members} />
+    </div>
+  );
+}
+
+function DashboardManageButton() {
+  return (
+    <div className='flex-center gap-16'>
+      <Button.Outline size='sm'>
+        <div className='hidden pr-8 tablet:block'>
+          <IconSettings />
+        </div>
+        관리
+      </Button.Outline>
+      <Button.Outline size='sm'>
+        <div className='hidden pr-8 tablet:block'>
+          <IconAddBox fill='#787486' />
+        </div>
+        초대하기
+      </Button.Outline>
+    </div>
   );
 }

--- a/src/pages/api/mock.ts
+++ b/src/pages/api/mock.ts
@@ -227,7 +227,7 @@ export const Mock_members: MembersProps = {
       isOwner: false,
     },
     {
-      id: 0,
+      id: 1,
       userId: 0,
       email: 'fsekjos@dlksd.net',
       nickname: '라마바',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,19 +1,9 @@
 import { useAtom } from 'jotai';
 import { loginAtom } from '@/store/loginAtom';
+import Header from '@/components/Header';
 
 function Home() {
-  const [loginInfo, setLoginInfo] = useAtom(loginAtom);
-  console.log(loginInfo);
-  const onClick = () => {
-    setLoginInfo({ isLoggedIn: false });
-  };
-
-  return (
-    <div className='p-20pxr'>
-      <button onClick={onClick}>CLICK</button>
-      <div>{loginInfo.nickname}</div>
-    </div>
-  );
+  return <Header />;
 }
 
 export default Home;


### PR DESCRIPTION
## 변경 사항
Close #3 
대시보드 페이지에서 사용되는 헤더를 구현했습니다.
현재는 각 대시보드 (/dashboard/{dashboardid}) 페이지로 이동했을 때 해당하는 대시보드의 이름이 동적으로 적용이 안되는데, 추후에 api를 연결하면서 구현할 예정입니다.

## 사용 방법
내려주는 프롭 없이 독립적으로 사용합니다.
```tsx
<Header/>
```

## 스크린샷 (선택 사항)
<img width="753" alt="스크린샷 2023-12-21 오후 2 19 05" src="https://github.com/Peachy-Peachy/Taskify/assets/83965026/41e6199e-2258-4ccd-87c8-8f13bb3ce49a">
<img width="754" alt="스크린샷 2023-12-21 오후 2 19 20" src="https://github.com/Peachy-Peachy/Taskify/assets/83965026/f22890ec-08b1-479a-84c6-58ed3796493c">
<img width="1065" alt="스크린샷 2023-12-21 오후 2 19 31" src="https://github.com/Peachy-Peachy/Taskify/assets/83965026/ac5c07cf-bf7c-4378-a813-66124dcb2d90">

