### PR TITLE
[feat] 레이아웃 구현

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react';
+import Header from './Header';
+import SideMenu from './SideMenu';
+
+interface Props {
+  children: ReactNode;
+}
+
+function Layout({ children }: Props) {
+  const emptyData = {
+    cursorId: 5,
+    totalCount: 0,
+    dashboards: [],
+  };
+
+  return (
+    <div className='flex bg-gray-1'>
+      <SideMenu data={emptyData.dashboards} />
+      <div className='flex w-full flex-col'>
+        <Header />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default Layout;

--- a/src/containers/MyDashboard/index.tsx
+++ b/src/containers/MyDashboard/index.tsx
@@ -1,6 +1,4 @@
 import { Mock_1_6_Invitations, Mock_1_6_dashboards } from '@/pages/api/mock';
-import Header from '@/components/Header';
-import SideMenu from '@/components/SideMenu';
 import Table from '@/components/tables';
 import MyDashboardButtons from './components/MyDashboardButtons';
 
@@ -23,19 +21,13 @@ function MyDashboard() {
   };
 
   return (
-    <div className='flex bg-gray-1'>
-      <SideMenu data={emptyData.dashboards} />
-      <div className='flex w-full flex-col'>
-        <Header />
-        <div className='flex w-full max-w-[64rem] flex-col gap-24 p-24 tablet:gap-44 tablet:p-40'>
-          <MyDashboardButtons data={emptyData.dashboards} totalCount={0} />
-          <Table
-            type='dashboard'
-            data={invitations}
-            totalCount={emptyInvitedData.invitations.length}
-          />
-        </div>
-      </div>
+    <div className='flex w-full max-w-[64rem] flex-col gap-24 p-24 tablet:gap-44 tablet:p-40'>
+      <MyDashboardButtons data={emptyData.dashboards} totalCount={0} />
+      <Table
+        type='dashboard'
+        data={invitations}
+        totalCount={emptyInvitedData.invitations.length}
+      />
     </div>
   );
 }

--- a/src/pages/mydashboard.tsx
+++ b/src/pages/mydashboard.tsx
@@ -1,7 +1,12 @@
 import MyDashboard from '@/containers/MyDashboard';
+import Layout from '@/components/Layout';
 
 function MyDashboardPage() {
-  return <MyDashboard />;
+  return (
+    <Layout>
+      <MyDashboard />
+    </Layout>
+  );
 }
 
 export default MyDashboardPage;


### PR DESCRIPTION
## 변경 사항
Close #76 
대시보드 레이아웃을 구현했습니다.
사이드 메뉴 및 헤더가 들어갑니다.

## 사용 방법
```tsx
<Layout>{페이지 컴포넌트}<Layout/>
```

