### PR TITLE
[feat] ImageUrl atom 구현

### DIFF
--- a/src/components/image-drop/ImageDrop.tsx
+++ b/src/components/image-drop/ImageDrop.tsx
@@ -1,5 +1,7 @@
+import { useSetAtom } from 'jotai';
 import Image from 'next/image';
 import useRequest from '@/hooks/useRequest';
+import { ImageUrlAtom } from '@/store/imageUrlAtom';
 import { IconAddLogo, IconEditLogo } from '@/public/svgs';
 
 interface ImageDropType {
@@ -39,10 +41,15 @@ function ImageDrop({ type, columnId }: ImageDropType) {
     },
   });
 
+  const setImageUrl = useSetAtom(ImageUrlAtom);
+
   const handleChangeImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!(e.target.files && e.target.files[0])) return;
     imageFormData.append('image', e.target.files[0]);
-    fetch();
+    const { data: nextImage } = await fetch();
+    if (nextImage) {
+      setImageUrl(nextImage);
+    }
   };
 
   return (

--- a/src/store/imageUrlAtom.ts
+++ b/src/store/imageUrlAtom.ts
@@ -1,0 +1,8 @@
+import { atom } from 'jotai';
+
+interface ImageUrl {
+  profileImageUrl?: string;
+  imageUrl?: string;
+}
+
+export const ImageUrlAtom = atom<ImageUrl>({});


### PR DESCRIPTION
## 변경 사항
ImageDrop 컴포넌트에서 업로드 한 이미지 주소를 atom을 통해 받아올 수 있도록 했습니다.

## 사용 방법
```ts
const ImageUrl = useAtomValue(imageUrlAtom)
```