### PR TITLE
[feat] myDashboard page columns 생성/수정 기능

### DIFF
--- a/src/components/inputs/Input.tsx
+++ b/src/components/inputs/Input.tsx
@@ -12,6 +12,8 @@ export type Props = {
   onInput?: React.ChangeEventHandler<HTMLInputElement>;
   tagList?: string[];
   setTagList?: (tagList: string[]) => void;
+  columnName?: string;
+  columnId?: string;
 };
 
 function Label({ title, required }: Props) {

--- a/src/components/inputs/InputComponents/TextInput.tsx
+++ b/src/components/inputs/InputComponents/TextInput.tsx
@@ -1,26 +1,36 @@
-import { useSetAtom } from 'jotai';
-import React, { ReactNode } from 'react';
+import { useAtom, useSetAtom } from 'jotai';
+import React, { ReactNode, useEffect } from 'react';
 import { ColumnsAtom } from '@/store/columnsAtom';
 
 function TextInput({
   required,
   children,
+  columnName,
   ...rest
 }: {
   required: boolean;
   children: ReactNode;
+  columnName?: string;
 }) {
-  const setColumn = useSetAtom(ColumnsAtom);
+  const [columnTitle, setColumnTitle] = useAtom(ColumnsAtom);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
-    setColumn({ newColumn: value });
+    setColumnTitle({ columnTitle: value });
   };
+
+  useEffect(() => {
+    if (columnName) {
+      setColumnTitle({ columnTitle: columnName });
+    }
+  }, []);
+
   return (
     <input
       className='input'
       onChange={handleChange}
       required={required}
+      value={columnTitle.columnTitle}
       {...rest}
     >
       {children}

--- a/src/components/inputs/InputComponents/TextInput.tsx
+++ b/src/components/inputs/InputComponents/TextInput.tsx
@@ -1,4 +1,6 @@
+import { useSetAtom } from 'jotai';
 import React, { ReactNode } from 'react';
+import { ColumnsAtom } from '@/store/columnsAtom';
 
 function TextInput({
   required,
@@ -8,8 +10,19 @@ function TextInput({
   required: boolean;
   children: ReactNode;
 }) {
+  const setColumn = useSetAtom(ColumnsAtom);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setColumn({ newColumn: value });
+  };
   return (
-    <input className='input' required={required} {...rest}>
+    <input
+      className='input'
+      onChange={handleChange}
+      required={required}
+      {...rest}
+    >
       {children}
     </input>
   );

--- a/src/components/modal/FormComponents/ColumnForm.tsx
+++ b/src/components/modal/FormComponents/ColumnForm.tsx
@@ -56,7 +56,7 @@ function ColumnForm({
     },
   });
 
-  const handleClick = () => {
+  const handleReset = () => {
     onCloseModal();
     setColumnTitle({ columnTitle: '' });
   };
@@ -121,7 +121,7 @@ function ColumnForm({
         )}
 
         <div className='absolute bottom-0 flex gap-10 tablet:right-0'>
-          <Button.Secondary size='lg' onClick={handleClick}>
+          <Button.Secondary size='lg' onClick={handleReset}>
             취소
           </Button.Secondary>
           <Button size='lg'>생성</Button>

--- a/src/components/modal/FormComponents/ColumnForm.tsx
+++ b/src/components/modal/FormComponents/ColumnForm.tsx
@@ -1,39 +1,133 @@
-import React from 'react';
+import axios from 'axios';
+import { useAtom, useAtomValue } from 'jotai';
+import { useParams } from 'next/navigation';
+import React, { useState } from 'react';
+import useRequest from '@/hooks/useRequest';
+import { ColumnsAtom } from '@/store/columnsAtom';
 import { Button } from '@/components/buttons';
 import Input from '@/components/inputs/Input';
 
 interface Props {
   onCloseModal: () => void;
   type: 'create' | 'edit';
+  columnName?: string;
+  columnId?: string;
 }
 
-function handleSubmit() {
-  console.log('aaaa');
+interface CreateColumnType {
+  title: string;
+  dashboardId: string;
 }
-function ColumnForm({ onCloseModal, type = 'create' }: Props) {
+
+interface EditColumnType {
+  title: string;
+  dashboardId: string;
+}
+
+function ColumnForm({
+  onCloseModal,
+  type = 'create',
+  columnName,
+  columnId,
+}: Props) {
+  const [errorMessage, setErrorMessage] = useState('');
+  const [columnTitle, setColumnTitle] = useAtom(ColumnsAtom);
+  const { dashboardId } = useParams();
   const title = type === 'edit' ? '컬럼 관리' : '새 컬럼 생성';
-  return (
-    <form className='mb-70 flex flex-col gap-30'>
-      <h1 className='heading1-bold'>{title}</h1>
-      <Input type='text' title='이름' placeholder='이름을 입력해 주세요' />
-      {type === 'edit' && (
-        <button
-          type='button'
-          className='absolute bottom-0 left-0 text-14 text-gray-4 underline'
-        >
-          삭제하기
-        </button>
-      )}
 
-      <div className='absolute bottom-0 flex gap-10 tablet:right-0'>
-        <Button.Secondary size='lg' onClick={onCloseModal}>
-          취소
-        </Button.Secondary>
-        <Button size='lg' onClick={handleSubmit}>
-          생성
-        </Button>
-      </div>
-    </form>
+  const { fetch: createColumn } = useRequest<CreateColumnType>({
+    skip: true,
+    options: {
+      url: 'columns',
+      method: 'post',
+      data: {
+        title: columnTitle.columnTitle,
+        dashboardId: Number(dashboardId),
+      },
+    },
+  });
+
+  const { fetch: editColumn } = useRequest<EditColumnType>({
+    skip: true,
+    options: {
+      url: `columns/${columnId}`,
+      method: 'put',
+      data: { title: columnTitle.columnTitle },
+    },
+  });
+
+  const handleClick = () => {
+    onCloseModal();
+    setColumnTitle({ columnTitle: '' });
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (title === '새 컬럼 생성') {
+      const { data, error } = await createColumn();
+      if (data) {
+        onCloseModal();
+        setColumnTitle({ columnTitle: '' });
+        return;
+      }
+
+      if (!axios.isAxiosError(error)) return;
+
+      if (error.response?.status === 400) {
+        setErrorMessage(error.response.data.message);
+      } else if (error.response?.status === 404) {
+        setErrorMessage(error.response.data.message);
+      }
+    } else {
+      const { data, error } = await editColumn();
+      if (data) {
+        onCloseModal();
+        setColumnTitle({ columnTitle: '' });
+        return;
+      }
+
+      if (!axios.isAxiosError(error)) return;
+
+      if (error.response?.status === 400) {
+        setErrorMessage(error.response.data.message);
+      } else if (error.response?.status === 404) {
+        setErrorMessage(error.response.data.message);
+      }
+    }
+  };
+
+  return (
+    <>
+      <form className='mb-70 flex flex-col gap-30' onSubmit={handleSubmit}>
+        <h1 className='heading1-bold'>{title}</h1>
+        <div>
+          <Input
+            type='text'
+            title='이름'
+            placeholder='이름을 입력해 주세요'
+            columnName={columnName}
+          />
+          {errorMessage && (
+            <small className='body2-normal mt-5 text-red'>{errorMessage}</small>
+          )}
+        </div>
+        {type === 'edit' && (
+          <button
+            type='button'
+            className='absolute bottom-0 left-0 text-14 text-gray-4 underline'
+          >
+            삭제하기
+          </button>
+        )}
+
+        <div className='absolute bottom-0 flex gap-10 tablet:right-0'>
+          <Button.Secondary size='lg' onClick={handleClick}>
+            취소
+          </Button.Secondary>
+          <Button size='lg'>생성</Button>
+        </div>
+      </form>
+    </>
   );
 }
 

--- a/src/containers/MyDashboard/[id]/components/DashboardColumn.tsx
+++ b/src/containers/MyDashboard/[id]/components/DashboardColumn.tsx
@@ -34,7 +34,11 @@ function DashboardColumn({
   if (!cardList) return;
   return (
     <div className='flex w-full flex-col border-gray-2 pc:w-354 pc:border-r'>
-      <ColumnInfo title={title} totalCount={cardList.totalCount} />
+      <ColumnInfo
+        title={title}
+        totalCount={cardList.totalCount}
+        columnId={columnId}
+      />
       <div className='flex flex-col gap-10 border-b border-gray-2 px-12 pb-12 tablet:gap-16 tablet:px-20 tablet:pb-20 pc:border-b-0'>
         <Modal>
           <AddCardButton />
@@ -54,9 +58,11 @@ export default DashboardColumn;
 function ColumnInfo({
   title,
   totalCount,
+  columnId,
 }: {
   title: string;
   totalCount: number;
+  columnId: string;
 }) {
   return (
     <div className='flex w-full items-center justify-between py-5 pr-12 tablet:py-20 tablet:pl-8 tablet:pr-20'>
@@ -65,7 +71,7 @@ function ColumnInfo({
         <p className='subheading-bold pr-12 tablet:pr-20'>{title}</p>
         <NumberChip num={totalCount} />
       </div>
-      <ManageButton />
+      <ManageButton title={title} columnId={columnId} />
     </div>
   );
 }
@@ -89,7 +95,12 @@ function AddCardButton() {
   );
 }
 
-function ManageButton() {
+interface ManageButtonType {
+  title: string;
+  columnId: string;
+}
+
+function ManageButton({ title, columnId }: ManageButtonType) {
   return (
     <Modal>
       <>
@@ -100,7 +111,11 @@ function ManageButton() {
         </Modal.Open>
         <Modal.Window name='modal-form'>
           <Form>
-            <Form.ColumnForm type='edit' />
+            <Form.ColumnForm
+              type='edit'
+              columnName={title}
+              columnId={columnId}
+            />
           </Form>
         </Modal.Window>
       </>

--- a/src/containers/MyDashboard/[id]/index.tsx
+++ b/src/containers/MyDashboard/[id]/index.tsx
@@ -1,6 +1,8 @@
-import { SetStateAction } from 'jotai';
+import { SetStateAction, useAtomValue } from 'jotai';
+import { useParams } from 'next/navigation';
 import { Dispatch, useEffect } from 'react';
 import useRequest from '@/hooks/useRequest';
+import { ColumnsAtom } from '@/store/columnsAtom';
 import {
   ColumnProps,
   ColumnsProps,
@@ -58,7 +60,7 @@ function Dashboard({ id, setCreatedByMe, setMembers }: DashboardProps) {
       setCreatedByMe(true);
       setMembers(memberList);
     }
-  }, [id, dashboardInfo?.createdByMe, memberList?.totalCount]);
+  }, [id, dashboardInfo?.createdByMe, columnsResponse, memberList?.totalCount]);
 
   if (!columnsResponse || !columnsResponse.result || !dashboardInfo) return;
 

--- a/src/containers/MyDashboard/[id]/index.tsx
+++ b/src/containers/MyDashboard/[id]/index.tsx
@@ -21,6 +21,7 @@ interface DashboardProps {
 }
 
 function Dashboard({ id, setCreatedByMe, setMembers }: DashboardProps) {
+  const { columnTitle } = useAtomValue(ColumnsAtom);
   const { data: columnsResponse, fetch: getColumns } = useRequest<
     ColumnsProps | undefined
   >({
@@ -60,7 +61,7 @@ function Dashboard({ id, setCreatedByMe, setMembers }: DashboardProps) {
       setCreatedByMe(true);
       setMembers(memberList);
     }
-  }, [id, dashboardInfo?.createdByMe, columnsResponse, memberList?.totalCount]);
+  }, [id, dashboardInfo?.createdByMe, columnTitle, memberList?.totalCount]);
 
   if (!columnsResponse || !columnsResponse.result || !dashboardInfo) return;
 

--- a/src/store/columnsAtom.ts
+++ b/src/store/columnsAtom.ts
@@ -1,7 +1,18 @@
 import { atom } from 'jotai';
 
 interface Column {
-  newColumn?: string;
+  columnTitle: string;
 }
 
-export const ColumnsAtom = atom<Column>({});
+const columnInit: Column = {
+  columnTitle: '',
+};
+
+export const ColumnsAtom = atom(
+  (get) => get(columnState),
+  (get, set, update: Column) => {
+    set(columnState, { ...get(columnState), ...update });
+  },
+);
+
+const columnState = atom(columnInit);

--- a/src/store/columnsAtom.ts
+++ b/src/store/columnsAtom.ts
@@ -1,0 +1,7 @@
+import { atom } from 'jotai';
+
+interface Column {
+  newColumn?: string;
+}
+
+export const ColumnsAtom = atom<Column>({});


### PR DESCRIPTION
## 변경 사항
close #106 

구조 파악하는데 늦었습니다.
Input 컴포넌트에서 값 상태관리를 jotai로(columnsAtom.ts) 사용했습니다.
생성/수정 시도했을 때 실시간 렌더링이 안돼서 /mydashboard/index.tsx의 디펜던시에 전체 컬럼 조회한 데이터를 추가했습니다.

문제점:
처음에 데이터를 받아온 columnsResponse 값을 디펜던시에 넣어줬는데 이렇게 되면 무한루프에 빠지게된다
해결 해보려고 상위컴포넌트에서 데이터를 요청해본다던가 등등 여러가지 방법을 사용해봤지만 무한루프에서 못빠져나왔다

해결방법:
쉬운 해결방법이였는데 너무 돌아서갔다 왔습니다. ㅜㅜ 
생성/수정작업하면서 전역 상태관리 jotai store에 ColumnAtom을 만들었는데 `const { columnTitle } = useAtomValue(ColumnsAtom);` 값을 가져와서 디펜던시에 columnTitle 만 넣어주면 해결된다.(columnTitle이 바뀔 때 마다 리렌더링)

## 사용 방법
<!--공통 컴포넌트/커스텀 훅 사용 방법에 대해 설명해주세요.-->

## 스크린샷 (선택 사항)
컬럼 10개 이상 만들어서... 에러메세지 출력

https://github.com/Peachy-Peachy/Taskify/assets/111848336/31d69d7f-a7d8-430e-afaa-e6ea6ad65285

