### PR TITLE
[fix] Table 컴포넌트 api 연결 및 edit 페이지에 적용

### DIFF
--- a/src/components/Members.tsx
+++ b/src/components/Members.tsx
@@ -20,7 +20,7 @@ const CONTAINER_SIZE = [
 
 export interface Member {
   id: number;
-  profileImageUrl?: string;
+  profileImageUrl?: string | null;
   nickname: string;
 }
 

--- a/src/components/tables/DashboardInfoTable.tsx
+++ b/src/components/tables/DashboardInfoTable.tsx
@@ -108,13 +108,12 @@ function InvitingButton() {
   );
 }
 
-function AccountInfo({
-  data,
-  fetch,
-}: {
+interface Props {
   data: MemberProps | InvitationProps;
   fetch: () => void;
-}) {
+}
+
+function AccountInfo({ data, fetch }: Props) {
   const router = useRouter();
   const { dashboardId } = router.query;
   let text, id, nickname, profileImageUrl;

--- a/src/components/tables/DashboardInfoTable.tsx
+++ b/src/components/tables/DashboardInfoTable.tsx
@@ -5,7 +5,6 @@ import { IconAddBox } from '@/public/svgs';
 import { DashboardInfoProps } from '.';
 import Members from '../Members';
 import { Button } from '../buttons';
-import ArrowButton from '../buttons/ArrowButton';
 import Form from '../modal/Form';
 import Modal from '../modal/Modal';
 
@@ -63,7 +62,7 @@ function TableHeader({
           <p className='body2-light'>
             {totalPage} 페이지 중 {currentPage}
           </p>
-          <ArrowButton
+          <Button.Arrow
             onLeftClick={handleLeftClick}
             onRightClick={handleRightClick}
             leftDisabled={currentPage === 1 ? true : false}

--- a/src/components/tables/DashboardInfoTable.tsx
+++ b/src/components/tables/DashboardInfoTable.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { DashboardsInvitationProps, MemberProps } from '@/pages/api/mock';
 import { IconAddBox } from '@/public/svgs';
+import { DashboardInfoProps } from '.';
 import Members from '../Members';
 import { Button } from '../buttons';
 import ArrowButton from '../buttons/ArrowButton';
@@ -10,21 +11,18 @@ import ArrowButton from '../buttons/ArrowButton';
 // const { totalCount: totalCount2, invitations } =
 //   Mock_dashboards_dashboardId_invitations;
 
-interface Props {
-  type: 'invitation' | 'member';
-  totalCount: number;
-  data: MemberProps[] | DashboardsInvitationProps[];
-}
-
-function DashboardInfoTable({ type, totalCount, data }: Props) {
-  const [currentPage, setCurrentPage] = useState(1);
+function DashboardInfoTable({
+  type,
+  totalCount,
+  data,
+  setCurrentPage,
+}: DashboardInfoProps) {
   // const data = get /1-6/members page=currentPage size=5 해서 MemberList로 넘겨주기(dep = currentPage)
 
   return (
     <div className='flex flex-col rounded-lg bg-white px-16 pt-24'>
       <TableHeader
         type={type}
-        currentPage={currentPage}
         setCurrentPage={setCurrentPage}
         totalCount={totalCount}
       />
@@ -40,18 +38,13 @@ export default DashboardInfoTable;
 
 interface HeaderProps {
   type: string;
-  currentPage: number;
   setCurrentPage: (arg: number) => void;
   totalCount: number;
 }
 
-function TableHeader({
-  type,
-  currentPage,
-  setCurrentPage,
-  totalCount,
-}: HeaderProps) {
+function TableHeader({ type, setCurrentPage, totalCount }: HeaderProps) {
   const totalPage = Math.floor(totalCount / 5) + 1;
+  const currentPage = 1;
 
   const handleLeftClick = () => setCurrentPage(currentPage - 1);
   const handleRightClick = () => setCurrentPage(currentPage + 1);
@@ -108,8 +101,8 @@ function AccountInfo({
   let text;
   let profile;
 
-  if ('email' in data) {
-    text = data.email;
+  if ('nickname' in data) {
+    text = data.nickname;
     profile = [
       {
         id: data.id,
@@ -118,12 +111,12 @@ function AccountInfo({
       },
     ];
   } else {
-    text = data.invitee.nickname;
+    text = data.invitee.email;
     profile = [
       {
         id: data.invitee.id,
         profileImageUrl: undefined,
-        nickname: data.invitee.nickname,
+        nickname: data.invitee.email,
       },
     ];
   }
@@ -131,7 +124,7 @@ function AccountInfo({
   return (
     <div className='flex shrink-0 items-center justify-between border-b border-gray-3 py-12 last:border-b-0 tablet:py-16'>
       <div className='flex items-center gap-8'>
-        {'invitee' in data && <Members members={profile} />}
+        {'nickname' in data && <Members members={profile} />}
         <p className='body1-light'>{text}</p>
       </div>
       <div className='shrink-0'>

--- a/src/components/tables/DashboardInfoTable.tsx
+++ b/src/components/tables/DashboardInfoTable.tsx
@@ -1,30 +1,24 @@
-import { useState } from 'react';
-import { DashboardsInvitationProps, MemberProps } from '@/pages/api/mock';
+import { InvitationProps, MemberProps } from '@/pages/api/mock';
 import { IconAddBox } from '@/public/svgs';
 import { DashboardInfoProps } from '.';
 import Members from '../Members';
 import { Button } from '../buttons';
 import ArrowButton from '../buttons/ArrowButton';
 
-//예시 데이터
-// const { totalCount, members } = Mock_members;
-// const { totalCount: totalCount2, invitations } =
-//   Mock_dashboards_dashboardId_invitations;
-
 function DashboardInfoTable({
   type,
   totalCount,
   data,
   setCurrentPage,
+  currentPage,
 }: DashboardInfoProps) {
-  // const data = get /1-6/members page=currentPage size=5 해서 MemberList로 넘겨주기(dep = currentPage)
-
   return (
     <div className='flex flex-col rounded-lg bg-white px-16 pt-24'>
       <TableHeader
         type={type}
         setCurrentPage={setCurrentPage}
         totalCount={totalCount}
+        currentPage={currentPage}
       />
       {totalCount > 0 &&
         data.map((account, key) => {
@@ -40,11 +34,16 @@ interface HeaderProps {
   type: string;
   setCurrentPage: (arg: number) => void;
   totalCount: number;
+  currentPage: number;
 }
 
-function TableHeader({ type, setCurrentPage, totalCount }: HeaderProps) {
+function TableHeader({
+  type,
+  setCurrentPage,
+  totalCount,
+  currentPage,
+}: HeaderProps) {
   const totalPage = Math.floor(totalCount / 5) + 1;
-  const currentPage = 1;
 
   const handleLeftClick = () => setCurrentPage(currentPage - 1);
   const handleRightClick = () => setCurrentPage(currentPage + 1);
@@ -93,11 +92,7 @@ function InvitingButton() {
   );
 }
 
-function AccountInfo({
-  data,
-}: {
-  data: MemberProps | DashboardsInvitationProps;
-}) {
+function AccountInfo({ data }: { data: MemberProps | InvitationProps }) {
   let text;
   let profile;
 

--- a/src/components/tables/index.tsx
+++ b/src/components/tables/index.tsx
@@ -9,8 +9,9 @@ import InvitedDashboardsTable from './InvitedDashboardsTable';
 export interface DashboardInfoProps {
   type: 'member' | 'invitation';
   totalCount: number;
-  data: MemberProps[] | DashboardsInvitationProps[];
+  data: MemberProps[] | InvitationProps[];
   setCurrentPage: (arg: number) => void;
+  currentPage: number;
 }
 
 interface InvitedDashboardsProps {
@@ -28,6 +29,7 @@ function Table(props: Props) {
       totalCount={props.totalCount}
       data={(props as DashboardInfoProps).data}
       setCurrentPage={props.setCurrentPage}
+      currentPage={props.currentPage}
     />
   ) : (
     <InvitedDashboardsTable

--- a/src/components/tables/index.tsx
+++ b/src/components/tables/index.tsx
@@ -12,6 +12,7 @@ export interface DashboardInfoProps {
   data: MemberProps[] | InvitationProps[];
   setCurrentPage: (arg: number) => void;
   currentPage: number;
+  fetch: () => void;
 }
 
 interface InvitedDashboardsProps {
@@ -30,6 +31,7 @@ function Table(props: Props) {
       data={(props as DashboardInfoProps).data}
       setCurrentPage={props.setCurrentPage}
       currentPage={props.currentPage}
+      fetch={props.fetch}
     />
   ) : (
     <InvitedDashboardsTable

--- a/src/components/tables/index.tsx
+++ b/src/components/tables/index.tsx
@@ -6,10 +6,11 @@ import {
 import DashboardInfoTable from './DashboardInfoTable';
 import InvitedDashboardsTable from './InvitedDashboardsTable';
 
-interface DashboardInfoProps {
+export interface DashboardInfoProps {
   type: 'member' | 'invitation';
   totalCount: number;
   data: MemberProps[] | DashboardsInvitationProps[];
+  setCurrentPage: (arg: number) => void;
 }
 
 interface InvitedDashboardsProps {
@@ -26,6 +27,7 @@ function Table(props: Props) {
       type={props.type}
       totalCount={props.totalCount}
       data={(props as DashboardInfoProps).data}
+      setCurrentPage={props.setCurrentPage}
     />
   ) : (
     <InvitedDashboardsTable

--- a/src/containers/Dashboard/Edit.tsx
+++ b/src/containers/Dashboard/Edit.tsx
@@ -35,7 +35,7 @@ function DashboardEdit({ dashboardId }: Props) {
   const { totalCount: InvitationsCount, invitations } = invitationList;
 
   return (
-    <div className='flex h-screen max-w-[41.25rem] flex-col gap-12 p-20'>
+    <div className='flex max-h-fit min-h-screen max-w-[41.25rem] flex-col gap-12 p-20'>
       <button className='flex-center body1-normal mb-8 w-80 gap-6'>
         <IconArrowBackward fill='#333236' />
         돌아가기

--- a/src/containers/Dashboard/Edit.tsx
+++ b/src/containers/Dashboard/Edit.tsx
@@ -17,7 +17,8 @@ function DashboardEdit({ dashboardId }: Props) {
   const { data: memberList, fetch: getMemberList } = useRequest<MembersProps>({
     skip: !dashboardId,
     options: {
-      url: `members?page=${currentMembersPage}&size=5&dashboardId=${dashboardId}`,
+      url: `members`,
+      params: { page: currentMembersPage, size: 5, dashboardId },
       method: 'get',
     },
     deps: [currentMembersPage, dashboardId],
@@ -35,7 +36,7 @@ function DashboardEdit({ dashboardId }: Props) {
 
   if (!memberList || !invitationList) return;
   const { totalCount: membersTotalCount, members } = memberList;
-  const { totalCount: InvitationsCount, invitations } = invitationList;
+  const { totalCount: invitationsCount, invitations } = invitationList;
 
   return (
     <div className='flex max-h-fit min-h-screen max-w-[41.25rem] flex-col gap-12 p-20'>
@@ -55,7 +56,7 @@ function DashboardEdit({ dashboardId }: Props) {
       <Table
         type='invitation'
         data={invitations}
-        totalCount={InvitationsCount}
+        totalCount={invitationsCount}
         setCurrentPage={setCurrentInvitationPage}
         currentPage={currentInvitationPage}
         fetch={getInvitationList}

--- a/src/containers/Dashboard/Edit.tsx
+++ b/src/containers/Dashboard/Edit.tsx
@@ -14,7 +14,7 @@ function DashboardEdit({ dashboardId }: Props) {
   const [currentMembersPage, setCurrentMembersPage] = useState(1);
   const [currentInvitationPage, setCurrentInvitationPage] = useState(1);
 
-  const { data: memberList } = useRequest<MembersProps>({
+  const { data: memberList, fetch: getMemberList } = useRequest<MembersProps>({
     options: {
       url: `members?page=${currentMembersPage}&size=5&dashboardId=${dashboardId}`,
       method: 'get',
@@ -22,13 +22,14 @@ function DashboardEdit({ dashboardId }: Props) {
     deps: [currentMembersPage, dashboardId],
   });
 
-  const { data: invitationList } = useRequest<InvitationsProps>({
-    options: {
-      url: `dashboards/${dashboardId}/invitations?page=${currentInvitationPage}&size=5`,
-      method: 'get',
-    },
-    deps: [currentInvitationPage, dashboardId],
-  });
+  const { data: invitationList, fetch: getInvitationList } =
+    useRequest<InvitationsProps>({
+      options: {
+        url: `dashboards/${dashboardId}/invitations?page=${currentInvitationPage}&size=5`,
+        method: 'get',
+      },
+      deps: [currentInvitationPage, dashboardId],
+    });
 
   if (!memberList || !invitationList) return;
   const { totalCount: membersTotalCount, members } = memberList;
@@ -47,6 +48,7 @@ function DashboardEdit({ dashboardId }: Props) {
         data={members}
         setCurrentPage={setCurrentMembersPage}
         currentPage={currentMembersPage}
+        fetch={getMemberList}
       />
       <Table
         type='invitation'
@@ -54,6 +56,7 @@ function DashboardEdit({ dashboardId }: Props) {
         totalCount={InvitationsCount}
         setCurrentPage={setCurrentInvitationPage}
         currentPage={currentInvitationPage}
+        fetch={getInvitationList}
       />
     </div>
   );

--- a/src/containers/Dashboard/Edit.tsx
+++ b/src/containers/Dashboard/Edit.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, SyntheticEvent, useEffect, useState } from 'react';
 import useRequest from '@/hooks/useRequest';
-import { MembersProps, Mock_1_6_Invitations } from '@/pages/api/mock';
+import { InvitationsProps, MembersProps } from '@/pages/api/mock';
 import { Button } from '@/components/buttons';
 import ColorChip from '@/components/chips/ColorChip';
 import Table from '@/components/tables';
@@ -11,19 +11,28 @@ interface Props {
 }
 
 function DashboardEdit({ dashboardId }: Props) {
-  const { invitations: data3 } = Mock_1_6_Invitations;
-  const [currentPage, setCurrentPage] = useState(1);
+  const [currentMembersPage, setCurrentMembersPage] = useState(1);
+  const [currentInvitationPage, setCurrentInvitationPage] = useState(1);
 
-  const { data: memberList, fetch: getMemberList } = useRequest<MembersProps>({
+  const { data: memberList } = useRequest<MembersProps>({
     options: {
-      url: `members?page=${currentPage}&size=5&dashboardId=${dashboardId}`,
+      url: `members?page=${currentMembersPage}&size=5&dashboardId=${dashboardId}`,
       method: 'get',
     },
-    deps: [currentPage, dashboardId],
+    deps: [currentMembersPage, dashboardId],
   });
 
-  if (!memberList) return;
-  const { totalCount, members } = memberList;
+  const { data: invitationList } = useRequest<InvitationsProps>({
+    options: {
+      url: `dashboards/${dashboardId}/invitations?page=${currentInvitationPage}&size=5`,
+      method: 'get',
+    },
+    deps: [currentInvitationPage, dashboardId],
+  });
+
+  if (!memberList || !invitationList) return;
+  const { totalCount: membersTotalCount, members } = memberList;
+  const { totalCount: InvitationsCount, invitations } = invitationList;
 
   return (
     <div className='flex h-screen max-w-[41.25rem] flex-col gap-12 p-20'>
@@ -34,15 +43,17 @@ function DashboardEdit({ dashboardId }: Props) {
       <TitleManageBox dashboardId={dashboardId} />
       <Table
         type='member'
-        totalCount={totalCount}
+        totalCount={membersTotalCount}
         data={members}
-        setCurrentPage={setCurrentPage}
+        setCurrentPage={setCurrentMembersPage}
+        currentPage={currentMembersPage}
       />
       <Table
         type='invitation'
-        data={data3}
-        totalCount={6}
-        setCurrentPage={setCurrentPage}
+        data={invitations}
+        totalCount={InvitationsCount}
+        setCurrentPage={setCurrentInvitationPage}
+        currentPage={currentInvitationPage}
       />
     </div>
   );

--- a/src/containers/Dashboard/Edit.tsx
+++ b/src/containers/Dashboard/Edit.tsx
@@ -15,6 +15,7 @@ function DashboardEdit({ dashboardId }: Props) {
   const [currentInvitationPage, setCurrentInvitationPage] = useState(1);
 
   const { data: memberList, fetch: getMemberList } = useRequest<MembersProps>({
+    skip: !dashboardId,
     options: {
       url: `members?page=${currentMembersPage}&size=5&dashboardId=${dashboardId}`,
       method: 'get',
@@ -24,6 +25,7 @@ function DashboardEdit({ dashboardId }: Props) {
 
   const { data: invitationList, fetch: getInvitationList } =
     useRequest<InvitationsProps>({
+      skip: !dashboardId,
       options: {
         url: `dashboards/${dashboardId}/invitations?page=${currentInvitationPage}&size=5`,
         method: 'get',

--- a/src/containers/Dashboard/Edit.tsx
+++ b/src/containers/Dashboard/Edit.tsx
@@ -1,57 +1,29 @@
 import { ChangeEvent, SyntheticEvent, useEffect, useState } from 'react';
 import useRequest from '@/hooks/useRequest';
-import { Mock_1_6_Invitations } from '@/pages/api/mock';
+import { MembersProps, Mock_1_6_Invitations } from '@/pages/api/mock';
 import { Button } from '@/components/buttons';
 import ColorChip from '@/components/chips/ColorChip';
 import Table from '@/components/tables';
 import { IconArrowBackward } from '@/public/svgs';
-
-const Mock_dashboards_dashboardId_invitations = {
-  totalCount: 0,
-  invitations: [
-    {
-      id: 0,
-      inviterUserId: 0,
-      teamId: 'string',
-      dashboard: {
-        title: 'string',
-        id: 0,
-      },
-      invitee: {
-        nickname: '김다은',
-        id: 0,
-      },
-      inviteAccepted: true,
-      createdAt: '2023-12-19T16:17:44.135Z',
-      updatedAt: '2023-12-19T16:17:44.135Z',
-    },
-    {
-      id: 0,
-      inviterUserId: 0,
-      teamId: 'string',
-      dashboard: {
-        title: 'string',
-        id: 0,
-      },
-      invitee: {
-        nickname: '김다은은',
-        id: 0,
-      },
-      inviteAccepted: true,
-      createdAt: '2023-12-19T16:17:44.135Z',
-      updatedAt: '2023-12-19T16:17:44.135Z',
-    },
-  ],
-};
 
 interface Props {
   dashboardId: string;
 }
 
 function DashboardEdit({ dashboardId }: Props) {
-  const { totalCount, invitations: data2 } =
-    Mock_dashboards_dashboardId_invitations;
   const { invitations: data3 } = Mock_1_6_Invitations;
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const { data: memberList, fetch: getMemberList } = useRequest<MembersProps>({
+    options: {
+      url: `members?page=${currentPage}&size=5&dashboardId=${dashboardId}`,
+      method: 'get',
+    },
+    deps: [currentPage, dashboardId],
+  });
+
+  if (!memberList) return;
+  const { totalCount, members } = memberList;
 
   return (
     <div className='flex h-screen max-w-[41.25rem] flex-col gap-12 p-20'>
@@ -60,8 +32,18 @@ function DashboardEdit({ dashboardId }: Props) {
         돌아가기
       </button>
       <TitleManageBox dashboardId={dashboardId} />
-      <Table type='member' totalCount={2} data={data2} />
-      <Table type='dashboard' data={data3} totalCount={6} />
+      <Table
+        type='member'
+        totalCount={totalCount}
+        data={members}
+        setCurrentPage={setCurrentPage}
+      />
+      <Table
+        type='invitation'
+        data={data3}
+        totalCount={6}
+        setCurrentPage={setCurrentPage}
+      />
     </div>
   );
 }

--- a/src/pages/api/mock.ts
+++ b/src/pages/api/mock.ts
@@ -39,6 +39,7 @@ export interface InvitationProps {
   };
   invitee: {
     nickname: string;
+    email: string;
     id: number;
   };
   inviteAccepted: boolean;
@@ -76,6 +77,7 @@ export interface DashboardsInvitationProps {
   };
   invitee: {
     nickname: string;
+    email: string;
     id: number;
   };
   inviteAccepted: boolean;
@@ -194,6 +196,7 @@ export const Mock_1_6_Invitations: InvitationsProps = {
       },
       invitee: {
         nickname: '임건우',
+        email: 'fkasehjio@fnjkd.com',
         id: 2,
       },
       inviteAccepted: false,
@@ -210,6 +213,7 @@ export const Mock_1_6_Invitations: InvitationsProps = {
       },
       invitee: {
         nickname: '윤진',
+        email: 'fkasehjio@fnjkd.com',
         id: 2,
       },
       inviteAccepted: false,
@@ -226,6 +230,7 @@ export const Mock_1_6_Invitations: InvitationsProps = {
       },
       invitee: {
         nickname: '강현지',
+        email: 'fkasehjio@fnjkd.com',
         id: 2,
       },
       inviteAccepted: false,
@@ -242,6 +247,7 @@ export const Mock_1_6_Invitations: InvitationsProps = {
       },
       invitee: {
         nickname: '남민섭',
+        email: 'fkasehjio@fnjkd.com',
         id: 2,
       },
       inviteAccepted: false,
@@ -258,6 +264,7 @@ export const Mock_1_6_Invitations: InvitationsProps = {
       },
       invitee: {
         nickname: '김다은',
+        email: 'fkasehjio@fnjkd.com',
         id: 2,
       },
       inviteAccepted: false,
@@ -274,6 +281,7 @@ export const Mock_1_6_Invitations: InvitationsProps = {
       },
       invitee: {
         nickname: '김다은',
+        email: 'fkasehjio@fnjkd.com',
         id: 2,
       },
       inviteAccepted: true,

--- a/src/pages/api/mock.ts
+++ b/src/pages/api/mock.ts
@@ -25,13 +25,17 @@ export interface GetDashboardInfoType {
 }
 
 export interface InvitationsProps {
-  cursorId: number;
   invitations: InvitationProps[];
+  totalCount: number;
 }
 
 export interface InvitationProps {
   id: number;
-  inviterUserId: number;
+  inviter: {
+    id: number;
+    email: string;
+    nickname: string;
+  };
   teamId: string;
   dashboard: {
     title: string;
@@ -42,7 +46,7 @@ export interface InvitationProps {
     email: string;
     id: number;
   };
-  inviteAccepted: boolean;
+  inviteAccepted: boolean | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -184,28 +188,35 @@ export const Mock_1_6_dashboards: DashboardsProps = {
 };
 
 export const Mock_1_6_Invitations: InvitationsProps = {
-  cursorId: 0,
   invitations: [
     {
-      id: 1,
-      inviterUserId: 3,
+      id: 604,
+      inviter: {
+        id: 68,
+        email: 'kde9889@naver.com',
+        nickname: '정우부인',
+      },
       teamId: '1-6',
       dashboard: {
-        title: '조타이 구현',
-        id: 3,
+        id: 123,
+        title: '테스트',
       },
       invitee: {
-        nickname: '임건우',
-        email: 'fkasehjio@fnjkd.com',
-        id: 2,
+        id: 111,
+        email: 'user@email.com',
+        nickname: 'useruser',
       },
-      inviteAccepted: false,
-      createdAt: '2023-12-19T05:41:19.594Z',
-      updatedAt: '2023-12-19T05:41:19.594Z',
+      inviteAccepted: null,
+      createdAt: '2023-12-30T02:15:46.793Z',
+      updatedAt: '2023-12-30T02:15:46.793Z',
     },
     {
       id: 1,
-      inviterUserId: 3,
+      inviter: {
+        id: 68,
+        email: 'kde9889@naver.com',
+        nickname: '정우부인',
+      },
       teamId: '1-6',
       dashboard: {
         title: 'Chip 대성공 ',
@@ -222,7 +233,11 @@ export const Mock_1_6_Invitations: InvitationsProps = {
     },
     {
       id: 1,
-      inviterUserId: 3,
+      inviter: {
+        id: 68,
+        email: 'kde9889@naver.com',
+        nickname: '정우부인',
+      },
       teamId: '1-6',
       dashboard: {
         title: '이사 완료!',
@@ -239,7 +254,11 @@ export const Mock_1_6_Invitations: InvitationsProps = {
     },
     {
       id: 1,
-      inviterUserId: 3,
+      inviter: {
+        id: 68,
+        email: 'kde9889@naver.com',
+        nickname: '정우부인',
+      },
       teamId: '1-6',
       dashboard: {
         title: '이미지 업로드',
@@ -256,7 +275,11 @@ export const Mock_1_6_Invitations: InvitationsProps = {
     },
     {
       id: 1,
-      inviterUserId: 3,
+      inviter: {
+        id: 68,
+        email: 'kde9889@naver.com',
+        nickname: '정우부인',
+      },
       teamId: '1-6',
       dashboard: {
         title: '일요일에 pr 올리지 말기',
@@ -273,7 +296,11 @@ export const Mock_1_6_Invitations: InvitationsProps = {
     },
     {
       id: 1,
-      inviterUserId: 3,
+      inviter: {
+        id: 68,
+        email: 'kde9889@naver.com',
+        nickname: '정우부인',
+      },
       teamId: '1-6',
       dashboard: {
         title: '졸려',
@@ -289,4 +316,5 @@ export const Mock_1_6_Invitations: InvitationsProps = {
       updatedAt: '2023-12-19T05:41:19.594Z',
     },
   ],
+  totalCount: 7,
 };


### PR DESCRIPTION
## 변경 사항
 Close #135 
- 테이블 컴포넌트 get, delete api 연결 및 edit 페이지에 적용
- 관련 API 백엔드 쪽에서 바꾼 부분 목데이터와 타입에 적용했으니 혹시 작업하실 때 쓸 일 있으면 참고 바랍니당

## 사용 방법
```
const [currentMembersPage, setCurrentMembersPage] = useState(1);

const { data: memberList } = useRequest<MembersProps>({
  skip: !dashboardId,
  options: {
    url: `members?page=${currentMembersPage}&size=5&dashboardId=${dashboardId}`,
    method: 'get',
  },
  deps: [currentMembersPage, dashboardId],
});

```
- 함수 자체를 내렸을 때 페이지 수정을 어떻게 할 지 고민되는 부분이 있어서 그냥 state 사용했는데 여유가 된다면 고도화를 해보겠습니다🤔🤔🤔

## 스크린샷 (선택 사항)

https://github.com/Peachy-Peachy/Taskify/assets/144599629/e5568c20-4376-4f0e-8f2c-051cab76e1d0

https://github.com/Peachy-Peachy/Taskify/assets/144599629/1ff4eaeb-9673-4f93-9768-5da0e1456e03


