### PR TITLE
[fix] modal component

### DIFF
--- a/src/components/modal/Confirm.tsx
+++ b/src/components/modal/Confirm.tsx
@@ -3,12 +3,16 @@ import { ConfirmComponents } from '@/components/modal/ConfirmComponents';
 
 interface Props {
   onCloseModal?: () => void;
+  onCloseAllModal?: () => void;
   children?: React.ReactNode;
 }
 
-function Confirm({ onCloseModal, children }: Props) {
+function Confirm({ onCloseModal, onCloseAllModal, children }: Props) {
   const childrenWithProps = React.Children.map(children, (child) =>
-    React.cloneElement(child as React.ReactElement<any>, { onCloseModal }),
+    React.cloneElement(child as React.ReactElement<any>, {
+      onCloseModal,
+      onCloseAllModal,
+    }),
   );
 
   return (

--- a/src/components/modal/ConfirmComponents/DeleteConfirm.tsx
+++ b/src/components/modal/ConfirmComponents/DeleteConfirm.tsx
@@ -21,9 +21,14 @@ function DeleteConfirm({ onCloseModal, columnId }: Props) {
   });
 
   const handleDelete = () => {
-    deleteColumn();
-    onCloseModal();
-    setColumnTitle({ columnTitle: '삭제' });
+    deleteColumn()
+      .then(() => {
+        onCloseModal();
+        setColumnTitle({ columnTitle: '삭제' });
+      })
+      .catch((error) => {
+        console.error('Failed to delete column:', error);
+      });
   };
   return (
     <>

--- a/src/components/modal/ConfirmComponents/DeleteConfirm.tsx
+++ b/src/components/modal/ConfirmComponents/DeleteConfirm.tsx
@@ -6,10 +6,11 @@ import { Button } from '@/components/buttons';
 
 interface Props {
   onCloseModal: () => void;
+  onCloseAllModal: () => void;
   columnId?: string;
 }
 
-function DeleteConfirm({ onCloseModal, columnId }: Props) {
+function DeleteConfirm({ onCloseModal, columnId, onCloseAllModal }: Props) {
   const setColumnTitle = useSetAtom(ColumnsAtom);
 
   const { fetch: deleteColumn } = useRequest({
@@ -23,11 +24,11 @@ function DeleteConfirm({ onCloseModal, columnId }: Props) {
   const handleDelete = () => {
     deleteColumn()
       .then(() => {
-        onCloseModal();
-        setColumnTitle({ columnTitle: '삭제' });
+        onCloseAllModal();
+        setColumnTitle({ columnTitle: '' });
       })
       .catch((error) => {
-        console.error('Failed to delete column:', error);
+        console.error('컬럼 삭제 실패 : ', error);
       });
   };
   return (

--- a/src/components/modal/Form.tsx
+++ b/src/components/modal/Form.tsx
@@ -3,12 +3,16 @@ import { FormComponents } from '@/components/modal/FormComponents';
 
 interface Props {
   onCloseModal?: () => void;
+  onCloseAllModal?: () => void;
   children?: React.ReactNode;
 }
 
-function Form({ onCloseModal, children }: Props) {
+function Form({ onCloseModal, onCloseAllModal, children }: Props) {
   const childrenWithProps = React.Children.map(children, (child) =>
-    React.cloneElement(child as React.ReactElement<any>, { onCloseModal }),
+    React.cloneElement(child as React.ReactElement<any>, {
+      onCloseModal,
+      onCloseAllModal,
+    }),
   );
   return (
     <div className='relative flex min-h-[12rem] flex-col bg-scroll tablet:min-h-[14rem]'>

--- a/src/components/modal/FormComponents/ColumnForm.tsx
+++ b/src/components/modal/FormComponents/ColumnForm.tsx
@@ -116,13 +116,11 @@ function ColumnForm({
           )}
         </div>
         {type === 'edit' && (
-          <Modal>
-            <DeleteCardButton handleReset={handleReset} columnId={columnId} />
-          </Modal>
+          <DeleteCardButton handleReset={handleReset} columnId={columnId} />
         )}
 
         <div className='absolute bottom-0 flex gap-10 tablet:right-0'>
-          <Button.Secondary size='lg' onClick={handleReset}>
+          <Button.Secondary type='button' size='lg' onClick={handleReset}>
             취소
           </Button.Secondary>
           <Button size='lg'>생성</Button>

--- a/src/components/modal/FormComponents/ColumnForm.tsx
+++ b/src/components/modal/FormComponents/ColumnForm.tsx
@@ -2,14 +2,11 @@ import axios from 'axios';
 import { useAtom, useAtomValue } from 'jotai';
 import { useParams } from 'next/navigation';
 import React, { useState } from 'react';
-import { Form } from 'react-hook-form';
 import useRequest from '@/hooks/useRequest';
 import { ColumnsAtom } from '@/store/columnsAtom';
 import { DeleteCardButton } from '@/containers/Dashboard/components/DashboardColumn';
 import { Button } from '@/components/buttons';
 import Input from '@/components/inputs/Input';
-import Confirm from '../Confirm';
-import Modal from '../Modal';
 
 interface Props {
   onCloseModal: () => void;

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -1,14 +1,18 @@
+import { useAtom } from 'jotai';
 import React, {
   cloneElement,
   createContext,
   useContext,
+  useEffect,
   useState,
 } from 'react';
 import { createPortal } from 'react-dom';
+import { ModalAtom } from '@/store/modalAtom';
 
 type ModalContextType = {
-  openName: string;
-  close: () => void;
+  openNames: string[];
+  close: (name: string) => void;
+  closeAll: () => void;
   open: (name: string) => void;
 };
 
@@ -25,9 +29,10 @@ interface BodyProps extends ModalProps {
 }
 
 const ModalContext = createContext<ModalContextType>({
-  openName: '',
-  close: () => {},
+  openNames: [],
   open: () => {},
+  close: () => {},
+  closeAll: () => {},
 });
 
 function Open({ children, opens: opensWindowName }: OpenProps) {
@@ -37,14 +42,14 @@ function Open({ children, opens: opensWindowName }: OpenProps) {
 }
 
 function Window({ children, name }: BodyProps) {
-  const { openName, close } = useContext(ModalContext);
-  if (name !== openName) return null;
+  const { openNames, close, closeAll } = useContext(ModalContext);
+  if (!openNames.includes(name)) return null;
 
   return createPortal(
     <div>
       <Backdrop />
       <div className='modal'>
-        <div>{cloneElement(children, { onCloseModal: close })}</div>
+        <div>{cloneElement(children, { onCloseModal: () => closeAll() })}</div>
       </div>
     </div>,
     document.body,
@@ -58,13 +63,33 @@ function Backdrop() {
 }
 
 function Modal({ children }: ModalProps) {
-  const [openName, setOpenName] = useState('');
+  const [openNames, setOpenNames] = useAtom(ModalAtom);
+  const open = (name: string) => {
+    openNames.openName.forEach((value) => console.log('open:' + value));
 
-  const close = () => setOpenName('');
-  const open = (name: string) => setOpenName(name);
+    if (!openNames.openName.includes(name)) {
+      setOpenNames({ openName: [...openNames.openName, name] });
+    }
+  };
+
+  const close = (name: string) => {
+    setOpenNames({ openName: openNames.openName.filter((n) => n !== name) });
+  };
+
+  const closeAll = () => {
+    setOpenNames({ openName: [] });
+  };
+
+  useEffect(() => {
+    openNames.openName.forEach((value) =>
+      console.log('Updated openNames: ' + value),
+    );
+  }, [openNames]);
 
   return (
-    <ModalContext.Provider value={{ openName, close, open }}>
+    <ModalContext.Provider
+      value={{ openNames: openNames.openName, close, closeAll, open }}
+    >
       {children}
     </ModalContext.Provider>
   );

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -1,11 +1,5 @@
 import { useAtom } from 'jotai';
-import React, {
-  cloneElement,
-  createContext,
-  useContext,
-  useEffect,
-  useState,
-} from 'react';
+import React, { cloneElement, createContext, useContext } from 'react';
 import { createPortal } from 'react-dom';
 import { ModalAtom } from '@/store/modalAtom';
 
@@ -49,7 +43,12 @@ function Window({ children, name }: BodyProps) {
     <div>
       <Backdrop />
       <div className='modal'>
-        <div>{cloneElement(children, { onCloseModal: () => closeAll() })}</div>
+        <div>
+          {cloneElement(children, {
+            onCloseModal: () => close(name),
+            onCloseAllModal: closeAll,
+          })}
+        </div>
       </div>
     </div>,
     document.body,
@@ -65,8 +64,6 @@ function Backdrop() {
 function Modal({ children }: ModalProps) {
   const [openNames, setOpenNames] = useAtom(ModalAtom);
   const open = (name: string) => {
-    openNames.openName.forEach((value) => console.log('open:' + value));
-
     if (!openNames.openName.includes(name)) {
       setOpenNames({ openName: [...openNames.openName, name] });
     }
@@ -79,12 +76,6 @@ function Modal({ children }: ModalProps) {
   const closeAll = () => {
     setOpenNames({ openName: [] });
   };
-
-  useEffect(() => {
-    openNames.openName.forEach((value) =>
-      console.log('Updated openNames: ' + value),
-    );
-  }, [openNames]);
 
   return (
     <ModalContext.Provider

--- a/src/containers/Dashboard/components/DashboardColumn.tsx
+++ b/src/containers/Dashboard/components/DashboardColumn.tsx
@@ -41,9 +41,8 @@ function DashboardColumn({
         columnId={columnId}
       />
       <div className='flex flex-col gap-10 border-b border-gray-2 px-12 pb-12 tablet:gap-16 tablet:px-20 tablet:pb-20 pc:border-b-0'>
-        <Modal>
-          <AddCardButton />
-        </Modal>
+        <AddCardButton />
+
         {cardList &&
           cardList.totalCount !== 0 &&
           cardList.cards.map((card: CardProps, key: number) => {
@@ -105,12 +104,12 @@ function ManageButton({ title, columnId }: ManageButtonType) {
   return (
     <Modal>
       <>
-        <Modal.Open opens='edit'>
+        <Modal.Open opens={`edit${columnId}`}>
           <button>
             <IconSettings />
           </button>
         </Modal.Open>
-        <Modal.Window name='edit'>
+        <Modal.Window name={`edit${columnId}`}>
           <Form>
             <Form.ColumnForm
               type='edit'
@@ -134,7 +133,7 @@ export function DeleteCardButton({
   return (
     <Modal>
       <>
-        <Modal.Open opens='delete'>
+        <Modal.Open opens={`delete${columnId}`}>
           <button
             type='button'
             className='absolute bottom-0 left-0 text-14 text-gray-4 underline'
@@ -142,7 +141,7 @@ export function DeleteCardButton({
             삭제하기
           </button>
         </Modal.Open>
-        <Modal.Window name='delete'>
+        <Modal.Window name={`delete${columnId}`}>
           <Confirm>
             <Confirm.DeleteConfirm
               columnId={columnId}

--- a/src/store/modalAtom.ts
+++ b/src/store/modalAtom.ts
@@ -1,0 +1,18 @@
+import { atom } from 'jotai';
+
+interface Modal {
+  openName: string[];
+}
+
+const ModalInit: Modal = {
+  openName: [],
+};
+
+export const ModalAtom = atom(
+  (get) => get(modalName),
+  (get, set, update: Modal) => {
+    set(modalName, { ...get(modalName), ...update });
+  },
+);
+
+const modalName = atom(ModalInit);


### PR DESCRIPTION
## 변경 사항
- 이중 모달을 사용할 경우, 한번에 닫히는 closeAll함수를 생성했습니다.
- 기존에 띄운 모달을 닫고 새로운 모달을 띄우도록 수정하는 것은 구현되지 않았습니다. 그저 모달 모두 닫기입니다.
- [ 할일 상세보기 모달 > 할일 수정모달 ] 등, 두 모달 모두 입력폼이 있는 경우의 동작방식을 얘기해보면 좋을 것 같습니다.
- 아래 스크린샷의 예시는 DeleteConfirm모달에서 
[ 취소버튼을 누를경우 : onCloseModal 함수 호출 , 삭제 버튼 누를 경우 : onCloseAllModal 함수 호출 ] 하도록 되어있는 예시입니다.
- close #142 

## 사용 방법
- Form.tsx와 Confirm.tsx에 onCloseAllModal 함수를 prop으로 넘겨주고 있습니다. 
(components/modal/Form.tsx, components/modal/Confirm.tsx)
<img width="1147" alt="image" src="https://github.com/Peachy-Peachy/Taskify/assets/96380950/7bab1d62-af08-43f4-8f27-5468e9ede4a5">
- 따라서 모든 모달을 닫아야하는 컴포넌트에서 prop으로 onCloseAllModal을 받아서 사용하시면 됩니다.
(예시 : components/modal/ConfirmComponents/DeleteConfirm.tsx)
<img width="738" alt="image" src="https://github.com/Peachy-Peachy/Taskify/assets/96380950/77c40b48-5da8-4df6-9aa3-f3f5b151077d">


## 스크린샷 (선택 사항)
![fix-modalComponent](https://github.com/Peachy-Peachy/Taskify/assets/96380950/9c4247bf-d919-4b9c-954f-2083b49b7880)

