### PR TITLE
[feat] dashboardId 페이지 더보기, 무한스크롤 기능 추가

### DIFF
--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -26,9 +26,11 @@ function Layout({ children }: Props) {
       {loginInfo.isLoggedIn ? (
         <div className='flex h-screen w-screen'>
           <SideMenu dashboardId={dashboardId} />
-          <div className='h-full w-full overflow-scroll bg-gray-1'>
+          <div className='overflow-hidden'>
             <DashboardHeader dashboardId={dashboardId} />
-            {children}
+            <div className='h-full w-full overflow-auto bg-gray-1'>
+              {children}
+            </div>
           </div>
         </div>
       ) : (

--- a/src/components/layouts/SideMenu.tsx
+++ b/src/components/layouts/SideMenu.tsx
@@ -25,7 +25,7 @@ function SideMenu({ dashboardId }: Props) {
   });
 
   return (
-    <div className='flex h-full w-67 flex-shrink-0 flex-col items-center overflow-y-scroll border-r border-gray-3 bg-white px-12 py-20 tablet:w-160 pc:w-300'>
+    <div className='flex h-full w-67 flex-shrink-0 flex-col items-center overflow-hidden border-r border-gray-3 bg-white px-12 py-20 tablet:w-160 pc:w-300'>
       <div className='w-full pb-60 pl-12'>
         <Logo />
       </div>

--- a/src/components/layouts/headers/DashboardHeader.tsx
+++ b/src/components/layouts/headers/DashboardHeader.tsx
@@ -50,7 +50,7 @@ function DashboardHeader({ dashboardId }: Props) {
   }, [dashboardId]);
 
   return (
-    <div className='sticky top-0 flex h-60 w-full items-center justify-between border-b border-solid border-gray-3 bg-white pl-24 pr-12 tablet:h-70 tablet:px-40 pc:pr-80'>
+    <div className='sticky top-0 z-nav flex h-60 w-full items-center justify-between border-b border-solid border-gray-3 bg-white pl-24 pr-12 tablet:h-70 tablet:px-40 pc:pr-80'>
       <div className='heading2-bold pl-4 pt-4'>{title}</div>
       <div className='flex-center body1-normal gap-12 tablet:gap-24'>
         {dashboardId && (
@@ -103,7 +103,7 @@ function ProfilePopup() {
 
   return (
     <div className='absolute -right-3 top-28 hidden bg-transparent pt-20 group-hover:block'>
-      <div className='shadow-popup flex h-100 w-130 flex-col justify-center overflow-hidden rounded-sm bg-white'>
+      <div className='flex h-100 w-130 flex-col justify-center overflow-hidden rounded-sm bg-white shadow-popup'>
         <ProfilePopupButton onClick={redirectMyPage}>
           마이 페이지
         </ProfilePopupButton>

--- a/src/components/layouts/headers/LandingHeader.tsx
+++ b/src/components/layouts/headers/LandingHeader.tsx
@@ -12,7 +12,7 @@ function LandingHeader() {
   };
 
   return (
-    <div className='flex h-60 w-full items-center justify-between bg-white px-24 tablet:h-70 tablet:pl-16 tablet:pr-40 pc:pr-80'>
+    <div className='z-nav flex h-60 w-full items-center justify-between bg-white px-24 tablet:h-70 tablet:pl-16 tablet:pr-40 pc:pr-80'>
       <div className='pl-4 pt-4'>
         <Logo />
       </div>

--- a/src/containers/Dashboard/DashboardId.tsx
+++ b/src/containers/Dashboard/DashboardId.tsx
@@ -1,13 +1,10 @@
-import { SetStateAction, useAtomValue } from 'jotai';
-import { useParams } from 'next/navigation';
-import { Dispatch, useEffect } from 'react';
+import { useAtomValue } from 'jotai';
 import useRequest from '@/hooks/useRequest';
 import { ColumnsAtom } from '@/store/columnsAtom';
 import {
   ColumnProps,
   ColumnsProps,
   GetDashboardInfoType,
-  MembersProps,
 } from '@/pages/api/mock';
 import AddChip from '@/components/chips/AddChip';
 import Form from '@/components/modal/Form';
@@ -23,33 +20,29 @@ function Dashboard({ id }: DashboardProps) {
   const { data: columnsResponse, fetch: getColumns } = useRequest<
     ColumnsProps | undefined
   >({
-    skip: true,
+    skip: !id,
     options: {
       url: `columns?dashboardId=${id}`,
       method: 'get',
     },
+    deps: [id, columnTitle],
   });
 
   const { data: dashboardInfo, fetch: getDashboardInfo } = useRequest<
     GetDashboardInfoType | undefined
   >({
-    skip: true,
+    skip: !id,
     options: {
       url: `dashboards/${id}`,
       method: 'get',
     },
+    deps: [id, columnTitle],
   });
-
-  useEffect(() => {
-    if (!id) return;
-    getColumns();
-    getDashboardInfo();
-  }, [id, dashboardInfo?.createdByMe, columnTitle]);
 
   if (!columnsResponse || !columnsResponse.result || !dashboardInfo) return;
 
   return (
-    <div className='flex min-h-screen flex-col pc:flex-row'>
+    <div className='flex min-h-screen min-w-fit flex-col pc:flex-row'>
       {columnsResponse.data.map((column: ColumnProps, key: number) => {
         return (
           <DashboardColumn

--- a/src/containers/Dashboard/components/DashboardColumn.tsx
+++ b/src/containers/Dashboard/components/DashboardColumn.tsx
@@ -17,14 +17,16 @@ function DashboardColumn({
   title: string;
   columnId: string;
 }) {
+  const [visible, setVisible] = useState(true);
   const [currentCursorId, setCurrentCursorId] = useState(0);
   const [list, setList] = useState<CardProps[]>([]);
+  const size = 5;
 
   const { data: initialCardList } = useRequest<CardsProps>({
     skip: !columnId,
     options: {
       url: `cards`,
-      params: { columnId: columnId, size: 5 },
+      params: { columnId: columnId, size: size },
       method: 'get',
     },
   });
@@ -34,7 +36,7 @@ function DashboardColumn({
     skip: !currentCursorId,
     options: {
       url: `cards`,
-      params: { columnId: columnId, size: 5, cursorId: currentCursorId },
+      params: { columnId: columnId, size: size, cursorId: currentCursorId },
       method: 'get',
     },
   });
@@ -50,6 +52,10 @@ function DashboardColumn({
   const handleClick = () => {
     setCurrentCursorId(cardList.cursorId);
     setList((prev) => [...prev, ...cardList.cards]);
+    if (cardList.cursorId === currentCursorId || cardList.cards.length < size) {
+      setVisible(false);
+      return;
+    }
   };
 
   return (
@@ -67,7 +73,7 @@ function DashboardColumn({
           list.map((card: CardProps, key: number) => {
             return <Card data={card} key={key} />;
           })}
-        <SeeMore handleClick={handleClick} />
+        {visible && <SeeMore handleClick={handleClick} />}
       </div>
     </div>
   );

--- a/src/containers/Dashboard/components/DashboardColumn.tsx
+++ b/src/containers/Dashboard/components/DashboardColumn.tsx
@@ -54,8 +54,7 @@ function DashboardColumn({ title, columnId }: Props) {
 
   const containerRef = useInfiniteScroll({
     handleScroll: handleClick,
-    initialList: initialCardList?.cards,
-    dependency: [initialCardList, cardList],
+    deps: [initialCardList, cardList],
   });
 
   useEffect(() => {

--- a/src/containers/Dashboard/components/DashboardColumn.tsx
+++ b/src/containers/Dashboard/components/DashboardColumn.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import useInfiniteScroll from '@/hooks/useInfiniteScroll';
 import useRequest from '@/hooks/useRequest';
 import { CardProps, CardsProps } from '@/pages/api/mock';
@@ -23,6 +23,7 @@ function DashboardColumn({ title, columnId }: Props) {
   const size = 5;
 
   const { data: initialCardList } = useRequest<CardsProps>({
+    deps: [columnId],
     skip: !columnId,
     options: {
       url: `cards`,
@@ -63,28 +64,26 @@ function DashboardColumn({ title, columnId }: Props) {
     setCurrentCursorId(initialCardList.cursorId);
   }, [initialCardList]);
 
-  if (!cardList || !cardList.cards) return;
+  if (!initialCardList || initialCardList.cards === undefined) return;
 
   return (
     <div className='flex w-full flex-col border-gray-2 pc:w-354 pc:border-r'>
       <ColumnInfo
         title={title}
-        totalCount={cardList.totalCount}
+        totalCount={initialCardList.totalCount}
         columnId={columnId}
       />
       <div className='flex flex-col gap-10 border-b border-gray-2 px-12 pb-12 tablet:gap-16 tablet:px-20 tablet:pb-20 pc:border-b-0'>
         <Modal>
           <AddCardButton />
         </Modal>
-        {cardList.totalCount !== 0 &&
+        {initialCardList.totalCount !== 0 &&
           list.map((card: CardProps, key: number) => {
             return <Card data={card} key={key} />;
           })}
         {visible && <SeeMore handleClick={handleClick} />}
         {visible && (
-          <p ref={containerRef} className='hidden pc:inline'>
-            무한 렌더링
-          </p>
+          <div ref={containerRef} className='hidden h-10 pc:inline' />
         )}
       </div>
     </div>

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -2,8 +2,8 @@ import { useEffect, useRef } from 'react';
 
 interface Props {
   handleScroll: () => void;
-  initialList: any[] | undefined;
-  dependency: any[] | undefined;
+  deps: any[] | undefined;
+  skip?: boolean;
   options?: {
     root: null | Element;
     rootMargin?: string;
@@ -13,8 +13,8 @@ interface Props {
 
 const useInfiniteScroll = ({
   handleScroll,
-  initialList,
-  dependency,
+  deps,
+  skip = false,
   options = {
     root: null,
     threshold: 0.6,
@@ -23,8 +23,7 @@ const useInfiniteScroll = ({
   const containerRef = useRef(null);
 
   useEffect(() => {
-    if (!initialList) return;
-
+    if (skip) return;
     const observer = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) handleScroll();
@@ -39,7 +38,7 @@ const useInfiniteScroll = ({
         observer.unobserve(containerRef.current);
       }
     };
-  }, dependency);
+  }, deps);
 
   return containerRef;
 };

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react';
+
+interface Props {
+  handleScroll: () => void;
+  initialList: any[] | undefined;
+  dependency: any[] | undefined;
+  options?: {
+    root: null | Element;
+    rootMargin?: string;
+    threshold: number;
+  };
+}
+
+const useInfiniteScroll = ({
+  handleScroll,
+  initialList,
+  dependency,
+  options = {
+    root: null,
+    threshold: 0.6,
+  },
+}: Props) => {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!initialList) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) handleScroll();
+      });
+    }, options);
+
+    if (containerRef.current) {
+      observer.observe(containerRef.current);
+    }
+    return () => {
+      if (containerRef.current) {
+        observer.unobserve(containerRef.current);
+      }
+    };
+  }, dependency);
+
+  return containerRef;
+};
+
+export default useInfiniteScroll;


### PR DESCRIPTION
## 변경 사항
Close #139 
- 모바일, 태블릿 사이즈에서는 더보기 클릭 시 데이터 새로 받아와짐
- PC에서는 무한스크롤로 size=5씩 받아와짐
- 무한스크롤 커스텀훅을 만들었는데 useRequest 쓰는 방식이 저와 비슷하지 않다면 사용성이 좋지 않을 수도 있을 것 같아요. 사용 안하셔도 되고, 사용하다 불편한 점 있으면 리뷰 담겨주시면 반영해보겠습니다 (직접 고치셔도 돼요)

## 사용 방법
- `useInfiniteScroll` 훅은 기본적으로 총 3개의 prop이 필요합니다
1. handleScroll: 바닥에 닿았을 때 어떤 작동을 할지 정하는 함수
      - 저같은 경우에는 get해오는 함수들의 디펜던시를 변경해주고, 더이상 데이터가 없을 시 기능을 off 해주는 함수를 넣어주고 있습니다. 
```
 const handleClick = () => {
    if (!cardList || !cardList.cards) return;
    setCurrentCursorId(cardList.cursorId);
    setList((prev) => [...prev, ...cardList.cards]);  // 기존 카드와 새로 받아온 카드 데이터 합치기
    if (cardList.cursorId === currentCursorId || cardList.cards.length < size) {
      setVisible(false);
      return;
    }
  };
```
2. skip: useRequest훅 skip과 같은 기능입니다

3. deps: 무한스크롤은 기본적으로 한 번 작동하면 기능이 off가 됩니다. 
      - 어떤 데이터가 바뀌었을 때 다시 기능을 on으로 해줄 지에 대한 정보가 필요합니다
     
4. options(선택): 기본으로 설정한 데이터 외의 설정이 필요하다면 이용해주세요. 예를들어, `root: null`인 경우 뷰포트 기준이기 때문에 Table 컴포넌트에서 무한스크롤을 할 시 해당 설정을 변경해주어야 합니다. 

- Intersection Observer API 사용했습니다
   - [mozilla](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
   - [참고자료 1](https://velog.io/@elrion018/%EC%8B%A4%EB%AC%B4%EC%97%90%EC%84%9C-%EB%8A%90%EB%82%80-%EC%A0%90%EC%9D%84-%EA%B3%81%EB%93%A4%EC%9D%B8-Intersection-Observer-API-%EC%A0%95%EB%A6%AC)
   - [참고자료 2](https://devpluto.tistory.com/entry/nextjs-intersection-observer%EB%A1%9C-%EB%AC%B4%ED%95%9C%EC%8A%A4%ED%81%AC%EB%A1%A4-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0)




## 스크린샷 (선택 사항)
- 모바일, 태블릿 사이즈: 더보기 버튼 (더이상 가져올 데이터가 없다면 더보기 버튼 비활성화)
- PC: 무한스크롤

https://github.com/Peachy-Peachy/Taskify/assets/144599629/40fec235-b28b-4721-99cd-ef5e7fbc8f87



### Error
- `무한스크롤이 작동한 대시보드 -> 다른 대시보드 -> 무한스크롤이 작동한 대시보드` 의 단계를 거쳤을 때 한 번 무한스크롤이 작동한 경우 무한스크롤이 안되는 문제가 발생하고 있습니다..... 에러 이슈 등록하고 고쳐보겠습니다
- 헤더에 `z-nav` (z-index=2) 를 줬더니 모달 화면보다 상위에 위치합니다. 모달은 수정 중이실 것 같아 파일을 안건들였는데 z-index 수정해주시면 감사하겠습니당
- 스크롤 3개 보이는거... UI 대박 별로인 것 같습니다🫥🫥 완전 수정 필요..!!!
![image](https://github.com/Peachy-Peachy/Taskify/assets/144599629/e03f4f64-f19e-406d-aac4-8e308769c51a)
- 가로스크롤 시 헤더 비어있는 것도 해결해야 됩니다...! 무한스크롤이 완벽하진 않아도 어느정도 구현이 돼서 급한 불을 껐으니 내일 수정해볼게요(혹은 헤더 많이 수정해야 되면 건우님한테 삐삐치겠습니다)
![image](https://github.com/Peachy-Peachy/Taskify/assets/144599629/8dfd7c6d-708b-4e63-8867-7d5d7f080828)
