### PR TITLE
[fix] 사이드 메뉴 대시보드 리스트 동기화

### DIFF
--- a/src/components/layouts/SideMenu.tsx
+++ b/src/components/layouts/SideMenu.tsx
@@ -1,6 +1,8 @@
+import { useAtom, useAtomValue } from 'jotai';
 import Link from 'next/link';
 import { useEffect } from 'react';
 import useRequest from '@/hooks/useRequest';
+import { dashboardUpdateAtom } from '@/store/dashboardUpdateAtom';
 import { DashboardProps, DashboardsProps } from '@/pages/api/mock';
 import DashBoardColorDot from '@/components/DashboardColorDot';
 import Logo from '@/components/logos/Logo';
@@ -13,6 +15,8 @@ interface Props {
 }
 
 function SideMenu({ dashboardId }: Props) {
+  const [dashboardUpdate, setDashboardUpdate] = useAtom(dashboardUpdateAtom);
+
   const { data, fetch } = useRequest<DashboardsProps>({
     options: {
       url: 'dashboards',
@@ -26,8 +30,10 @@ function SideMenu({ dashboardId }: Props) {
   });
 
   useEffect(() => {
+    if (dashboardUpdate === false) return;
     fetch();
-  }, [dashboardId]);
+    setDashboardUpdate(false);
+  }, [dashboardId, dashboardUpdate]);
 
   return (
     <div className='flex h-full w-67 flex-shrink-0 flex-col items-center overflow-hidden border-r border-gray-3 bg-white px-12 py-20 tablet:w-160 pc:w-300'>

--- a/src/components/layouts/SideMenu.tsx
+++ b/src/components/layouts/SideMenu.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { useEffect } from 'react';
 import useRequest from '@/hooks/useRequest';
 import { DashboardProps, DashboardsProps } from '@/pages/api/mock';
 import DashBoardColorDot from '@/components/DashboardColorDot';
@@ -12,7 +13,7 @@ interface Props {
 }
 
 function SideMenu({ dashboardId }: Props) {
-  const { data } = useRequest<DashboardsProps>({
+  const { data, fetch } = useRequest<DashboardsProps>({
     options: {
       url: 'dashboards',
       method: 'get',
@@ -23,6 +24,10 @@ function SideMenu({ dashboardId }: Props) {
       },
     },
   });
+
+  useEffect(() => {
+    fetch();
+  }, [dashboardId]);
 
   return (
     <div className='flex h-full w-67 flex-shrink-0 flex-col items-center overflow-hidden border-r border-gray-3 bg-white px-12 py-20 tablet:w-160 pc:w-300'>

--- a/src/components/layouts/headers/DashboardHeader.tsx
+++ b/src/components/layouts/headers/DashboardHeader.tsx
@@ -11,7 +11,7 @@ import Members from '@/components/Members';
 import { Button } from '@/components/buttons';
 import Form from '@/components/modal/Form';
 import Modal from '@/components/modal/Modal';
-import { IconAddBox, IconSettings } from '@/public/svgs';
+import { IconAddBox, IconCrown, IconSettings } from '@/public/svgs';
 
 interface Props {
   dashboardId?: string;
@@ -52,7 +52,14 @@ function DashboardHeader({ dashboardId }: Props) {
 
   return (
     <div className='sticky top-0 z-nav flex h-60 w-full items-center justify-between border-b border-solid border-gray-3 bg-white pl-24 pr-12 tablet:h-70 tablet:px-40 pc:pr-80'>
-      <div className='heading2-bold pl-4 pt-4'>{title}</div>
+      <div className='heading2-bold flex items-center gap-8 pl-4 pt-4'>
+        {title}
+        <IconCrown
+          className={
+            dashboardInfo?.createdByMe ? 'inline flex-shrink-0' : 'hidden'
+          }
+        />
+      </div>
       <div className='flex-center body1-normal gap-12 tablet:gap-24'>
         {dashboardId && (
           <DashboardInfo

--- a/src/components/modal/FormComponents/DashboardForm.tsx
+++ b/src/components/modal/FormComponents/DashboardForm.tsx
@@ -1,5 +1,7 @@
+import { useSetAtom } from 'jotai';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import useRequest from '@/hooks/useRequest';
+import { dashboardUpdateAtom } from '@/store/dashboardUpdateAtom';
 import { DashboardProps } from '@/pages/api/mock';
 import { Button } from '@/components/buttons';
 import ColorChip from '@/components/chips/ColorChip';
@@ -16,6 +18,8 @@ interface FormValues {
 }
 
 function DashboardForm({ onCloseModal, fetch }: Props) {
+  const setDashsboardUpdateAtom = useSetAtom(dashboardUpdateAtom);
+
   const { handleSubmit, control, formState } = useForm<FormValues>({
     defaultValues: {
       dashboardName: '',
@@ -47,6 +51,7 @@ function DashboardForm({ onCloseModal, fetch }: Props) {
 
     onCloseModal();
     fetch?.();
+    setDashsboardUpdateAtom(true);
   };
 
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/store/dashboardUpdateAtom.tsx
+++ b/src/store/dashboardUpdateAtom.tsx
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const dashboardUpdateAtom = atom(false);


### PR DESCRIPTION
## 변경 사항
새로운 대시보드를 생성 했을 때 사이드 메뉴에서 대시보드 리스트가 바로 업데이트 되도록 구현했습니다.
자신이 만든 대시보드 페이지에서 헤더에 왕관 아이콘이 뜨도록 했습니다.

