### PR TITLE
[fix] 대시보드 title 글자 수 표시 제한

### DIFF
--- a/src/components/layouts/SideMenu.tsx
+++ b/src/components/layouts/SideMenu.tsx
@@ -6,6 +6,7 @@ import useInfiniteScroll from '@/hooks/useInfiniteScroll';
 import { themeAtom } from '@/store/colorSchemeAtom';
 import { dashboardUpdateAtom } from '@/store/dashboardUpdateAtom';
 import { openModal } from '@/store/modalAtom';
+import { reduceText } from '@/utils/reduceText';
 import fetch from '@/services/utils/fetch';
 import { DashboardProps, DashboardsProps } from '@/pages/api/mock';
 import DashBoardColorDot from '@/components/DashboardColorDot';
@@ -64,12 +65,12 @@ function SideMenu({ dashboardId }: Props) {
   }, [dashboardId, dashboardUpdate]);
 
   return (
-    <div className='flex h-full w-67 flex-shrink-0 flex-col items-center overflow-hidden border-r border-gray-3 bg-white px-12 pb-70 pt-20 tablet:w-160 pc:w-300'>
+    <div className='flex h-full w-67 flex-shrink-0 flex-col items-center overflow-hidden border-r border-gray-3 bg-white px-12 pb-75 pt-20 tablet:w-160 pc:w-300'>
       <div className='w-full pb-60 pl-12'>
         <Logo />
       </div>
       <DashboardsHeader />
-      <ul className='flex h-full w-full flex-col gap-5 overflow-auto'>
+      <ul className='flex h-full w-full flex-col gap-5 overflow-y-auto overflow-x-hidden'>
         {dashboards?.pages.map((dashboardPage) =>
           dashboardPage.dashboards.map((dashboard) => (
             <li key={dashboard.id}>
@@ -137,6 +138,9 @@ function DashboardCard({
 }: DashboardCardProps) {
   const theme = useAtomValue(themeAtom);
 
+  const reducedTitlePc = reduceText(title, 11);
+  const reducedTitleTablet = reduceText(title, 4);
+
   return (
     <Link
       href={`/dashboard/${id}`}
@@ -148,8 +152,9 @@ function DashboardCard({
     >
       <DashBoardColorDot color={color} />
       <div className='hidden items-center pr-12 tablet:flex'>
-        <p className='heading3-normal pc:heading2-normal px-6 text-gray-5'>
-          {title}
+        <p className='heading3-normal pc:heading2-normal break-keep px-6 text-gray-5'>
+          <span className='hidden pc:inline'>{reducedTitlePc}</span>
+          <span className='pc:hidden'>{reducedTitleTablet}</span>
         </p>
         <IconCrown
           className={createdByMe ? 'inline flex-shrink-0' : 'hidden'}

--- a/src/containers/Dashboard/components/MyDashboardButton.tsx
+++ b/src/containers/Dashboard/components/MyDashboardButton.tsx
@@ -1,5 +1,6 @@
 import { useAtomValue } from 'jotai';
 import { themeAtom } from '@/store/colorSchemeAtom';
+import { reduceText } from '@/utils/reduceText';
 import { DashboardProps } from '@/pages/api/mock';
 import DashboardColorDot from '@/components/DashboardColorDot';
 import DashboardButton from '@/components/buttons/DashboardButton';
@@ -8,12 +9,15 @@ import { IconArrowForward, IconCrown } from '@/public/svgs';
 function MyDashboardButton({ data }: { data: DashboardProps }) {
   const theme = useAtomValue(themeAtom);
   const { title, color, createdByMe } = data;
+  const reducedTitle = reduceText(title, 10);
   return (
     <DashboardButton size='lg'>
       <div className='flex w-11/12 items-center justify-between '>
         <div className='flex items-center'>
           <DashboardColorDot color={color} />
-          <p className='heading3-normal pl-6 pr-8 text-gray-6'>{title}</p>
+          <p className='heading3-normal pl-6 pr-8 text-gray-6'>
+            {reducedTitle}
+          </p>
           <IconCrown
             className={createdByMe ? 'inline flex-shrink-0' : 'hidden'}
           />

--- a/src/utils/reduceText.ts
+++ b/src/utils/reduceText.ts
@@ -1,0 +1,8 @@
+export const reduceText = (text: string | undefined, length: number) => {
+  if (!text) return;
+  if (text.length > length) {
+    return `${text.slice(0, length)}...`;
+  } else {
+    return text;
+  }
+};


### PR DESCRIPTION
## 변경 사항
사이드 메뉴 및 대시보드 버튼에 표시되는 글자 수를 제한했습니다.

### 스크린샷
<img width="1440" alt="스크린샷 2024-01-04 오후 10 57 10" src="https://github.com/Peachy-Peachy/Taskify/assets/83965026/f2051d66-bf43-4d93-96d8-43f9c1aa1073">

<img width="859" alt="스크린샷 2024-01-04 오후 10 57 20" src="https://github.com/Peachy-Peachy/Taskify/assets/83965026/19c65752-665f-43e6-b2b7-8cef135eac0f">
